### PR TITLE
Fix tests where attr order is not defined

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -39,7 +39,8 @@ my $tag = Tag.new;
 {
     # named parameters means tag attributes
     is $tag.hr(:class<foo>), '<hr class="foo">';
-    is $tag.img(:src<a.jpg>, :alt('1 > 2')), '<img src="a.jpg" alt="1 &gt; 2">';
+    ok $tag.img(:src<a.jpg>, :alt('1 > 2'))
+        ~~ / '<img src="a.jpg" alt="1 &gt; 2">' || '<img alt="1 &gt; 2" src="a.jpg">' /;
 }
 
 {
@@ -77,7 +78,8 @@ my $tag = Tag.new;
 {
     # methods can be called statically
     is Tag.b('hello'), '<b>hello</b>';
-    is Tag.begin_form(:action<.>, :method<POST>), '<form action="." method="POST">';
+    ok Tag.begin_form(:action<.>, :method<POST>)
+        ~~ / '<form action="." method="POST">' || '<form method="POST" action=".">' /;
 }
 
 {


### PR DESCRIPTION
Tag attributes can be generated in any order.  This commit lets the tests
check (in the given situations) the two different options which could occur
and thus the test suite passes again.